### PR TITLE
Moved arm64 to runtime scope

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -35,6 +35,7 @@
     <dependency>
       <groupId>io.zonky.test.postgres</groupId>
       <artifactId>embedded-postgres-binaries-linux-arm64v8</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
The dependency is not needed for compilation