### PR TITLE
Release 0.1.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: "0.0.9"
+  current-version: "0.1.0"
   next-version: "1.0.0-SNAPSHOT"


### PR DESCRIPTION
Similar to other extension qe will use 0.1.x for quarkus 3 releases and 0.0.x for quarkus 2 releases. Since this is the first one for quarkus 3, the version is 0.1.0