### PR TITLE
Adding stringtype property

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-embedded-postgresql.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-embedded-postgresql.adoc
@@ -60,4 +60,21 @@ endif::add-copy-button-to-env-var[]
 --|int 
 |
 
+
+a| [[quarkus-embedded-postgresql_quarkus.embedded.postgresql.stringtype]]`link:#quarkus-embedded-postgresql_quarkus.embedded.postgresql.stringtype[quarkus.embedded.postgresql.stringtype]`
+
+
+[.description]
+--
+Set string type
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_EMBEDDED_POSTGRESQL_STRINGTYPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_EMBEDDED_POSTGRESQL_STRINGTYPE+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|`unspecified`
+
 |===

--- a/runtime/src/main/java/io/quarkiverse/embedded/postgresql/EmbeddedPostgreSQLConfiguration.java
+++ b/runtime/src/main/java/io/quarkiverse/embedded/postgresql/EmbeddedPostgreSQLConfiguration.java
@@ -27,4 +27,12 @@ public class EmbeddedPostgreSQLConfiguration {
     @ConfigItem(name = "port")
     public Optional<Integer> port;
 
+    /**
+     * Set string type
+     *
+     * @see https://jdbc.postgresql.org/documentation/use/
+     */
+    @ConfigItem(name = "stringtype", defaultValue = "unspecified")
+    public String stringtype;
+
 }

--- a/runtime/src/main/java/io/quarkiverse/embedded/postgresql/EmbeddedPostgreSQLRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/embedded/postgresql/EmbeddedPostgreSQLRecorder.java
@@ -44,6 +44,9 @@ public class EmbeddedPostgreSQLRecorder {
                     builder.setPort(port);
                 });
 
+        builder.setConnectConfig("stringtype",
+                config.getOptionalValue("quarkus.embedded.postgresql.stringtype", String.class).orElse("unspecified"));
+
         config.getOptionalValue("quarkus.embedded.postgresql.startup.wait", Long.class).ifPresent(
                 timeout -> {
                     logger.infov("PG startup timeout set to {0}", timeout);


### PR DESCRIPTION
Adding `quarkus.embedded.postgresql.stringtype `property. Default value is unspecified, which allows usage of custom types as strings, for example jsonb. 