### PR TITLE
Update to the latest Quarkus LTS version and latest Zonky library.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
+    <compiler-plugin.version>3.13.0</compiler-plugin.version>
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.7.1</quarkus.version>
-    <version.io.zonky.test>2.0.4</version.io.zonky.test>
+    <quarkus.version>3.8.4</quarkus.version>
+    <version.io.zonky.test>2.0.7</version.io.zonky.test>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Hi, this PR updates the Quarkus version to the latest LTS version (3.8.4) and updates the Zonky library to the latest version. 