### PR TITLE
Proper Dependabot ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,7 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "org.apache.maven.plugins:maven-compiler-plugin"
+      - dependency-name: "io.quarkus:quarkus-bom"
+      - dependency-name: "io.quarkus:quarkus-extension-processor"
+      - dependency-name: "io.quarkus:quarkus-maven-plugin"
+      - dependency-name: "io.quarkus:quarkus-extension-maven-plugin"


### PR DESCRIPTION
This ignores Quarkus updates and lets us control LTS releases so we are on 3.8.4 and should remain until the next LTS release.