### PR TITLE
Bump `quarkus.version` from `3.8.6` to `3.15.3`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.8.6</quarkus.version>
+    <quarkus.version>3.15.3</quarkus.version>
     <version.io.zonky.test>2.0.7</version.io.zonky.test>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
Bumping quarkus version to the new `3.15.3` LTS.