### PR TITLE
Dev UI: always produce JsonRPCProvidersBuildItem

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/EmbeddedPostgreSQLDevUIProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/EmbeddedPostgreSQLDevUIProcessor.java
@@ -29,7 +29,7 @@ public class EmbeddedPostgreSQLDevUIProcessor {
         cardPageBuildItemBuildProducer.produce(card);
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem createJsonRPCService() {
         return new JsonRPCProvidersBuildItem(EmbeddedPostgreSQLJsonRpcService.class);
     }


### PR DESCRIPTION
This is due to an upcoming change in Execution Model Validation [1] where we need the `JsonRPCProvidersBuildItem` produced always, not only in dev mode. JSON RPC providers can use execution model affecting annotations, so we need to know about them, otherwise a non-dev build would fail with an incorrect validation error.

[1] https://github.com/quarkusio/quarkus/pull/46965