### PR TITLE
Upgrade to Quarkus 3.20.1.

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -21,7 +21,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+      <artifactId>quarkus-rest-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.embedded.postgresql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.15.3</quarkus.version>
+    <quarkus.version>3.20.1</quarkus.version>
     <version.io.zonky.test>2.1.0</version.io.zonky.test>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
This PR upgrades the library to use Quarkus 3.20.1, which is the latest LTS version of Quarkus currently available. 