### PR TITLE
Added the ability to specify listen_address to configure external con…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ You can now inject in your code a DataSource object (if you are JDBC friend) or 
 |----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
 | `quarkus.embedded.postgresql.data.dir` | You can optionally persist information into file system by setting the desired path as value of property                                           |  
 | `quarkus.embedded.postgresql.port`     | You can optinally configure the postgresql server port by using this property. If no value is confirured a random available port will be selected. |
+| `quarkus.embedded.postgresql.listen-address`     | You can optionally configure the host(s) (listen_addresses) for the PostgreSQL server; if not set, localhost is used. Valid values include localhost, 0.0.0.0, ::, *, a specific hostname or IP (e.g. db.mycompany.local, 192.168.1.100), or multiple comma-separated addresses. |
 
 ### Multiple Datasources
 

--- a/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/EmbeddedPostgreSQLProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/EmbeddedPostgreSQLProcessor.java
@@ -64,8 +64,10 @@ class EmbeddedPostgreSQLProcessor {
             DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig, EmbeddedPostgreSQLConfig postgreSQLConfig,
             BuildProducer<RunTimeConfigurationDefaultBuildItem> configProducer) {
         final int port = postgreSQLConfig.port().orElseGet(EmbeddedPostgreSQLConfigUtils::getDefaultPort);
+
         Map<String, String> dbNames = getDBNames(dataSourcesBuildTimeConfig);
-        recorder.startPostgres(shutdown, port, dbNames, postgreSQLConfig.stringType(), postgreSQLConfig.startupWait(),
+        recorder.startPostgres(shutdown, port, postgreSQLConfig.listenAddress(), dbNames, postgreSQLConfig.stringType(),
+                postgreSQLConfig.startupWait(),
                 postgreSQLConfig.dataDir());
         getConfig(port, dbNames).forEach((k, v) -> configProducer.produce(new RunTimeConfigurationDefaultBuildItem(k, v)));
         return new ServiceStartBuildItem(FEATURE);
@@ -144,9 +146,10 @@ class EmbeddedPostgreSQLProcessor {
 
         Map<String, String> dbNames = getDBNames(dataSourcesBuildTimeConfig);
 
-        EmbeddedPostgres pg = EmbeddedPostgreSQLDBUtils.startPostgres(postgreSQLConfig.port(), dbNames,
-                postgreSQLConfig.stringType(), postgreSQLConfig.startupWait(), postgreSQLConfig.dataDir());
-        Map<String, String> devServerConfigMap = EmbeddedPostgreSQLConfigUtils.getConfig(pg.getPort(), dbNames);
+        EmbeddedPostgres pg = EmbeddedPostgreSQLDBUtils.startPostgres(postgreSQLConfig.port(), postgreSQLConfig.listenAddress(),
+                dbNames, postgreSQLConfig.stringType(), postgreSQLConfig.startupWait(), postgreSQLConfig.dataDir());
+
+        Map<String, String> devServerConfigMap = getConfig(pg.getPort(), dbNames);
         Config config = ConfigProvider.getConfig();
         for (String propertyName : config.getPropertyNames()) {
             if (propertyName.startsWith("quarkus.embedded.postgresql.")) {

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -71,18 +71,141 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <executions>
           <execution>
-            <id>integration-test</id>
+            <id>integration-test-dev</id>
+            <phase>integration-test</phase>
             <goals>
               <goal>integration-test</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <quarkus.profile>prod</quarkus.profile>
+              </systemPropertyVariables>
+              <includes>
+                <include>**/*PostgreSQLFilesystemStorageTest.java</include>
+              </includes>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>integration-test-1</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <quarkus.profile>test</quarkus.profile>
+              </systemPropertyVariables>
+              <includes>
+                <include>**/*PostgreSQLFilesystemStorageTest.java</include>
+              </includes>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>integration-test-2</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <quarkus.profile>test2</quarkus.profile>
+              </systemPropertyVariables>
+              <includes>
+                <include>**/*PostgreSQLFilesystemStorageTest.java</include>
+              </includes>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>integration-test-3</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <quarkus.profile>test3</quarkus.profile>
+              </systemPropertyVariables>
+              <includes>
+                <include>**/*PostgreSQLFilesystemStorageTest.java</include>
+              </includes>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>integration-test-4</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <quarkus.profile>test4</quarkus.profile>
+              </systemPropertyVariables>
+              <includes>
+                <include>**/*PostgreSQLFilesystemStorageTest.java</include>
+              </includes>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>integration-test-5</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <quarkus.profile>test5</quarkus.profile>
+              </systemPropertyVariables>
+              <includes>
+                <include>**/*PostgreSQLFilesystemStorageTest.java</include>
+              </includes>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>integration-test-6</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <quarkus.profile>test6</quarkus.profile>
+              </systemPropertyVariables>
+              <includes>
+                <include>**/*PostgreSQLFilesystemStorageTest.java</include>
+              </includes>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>integration-test-7</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <quarkus.profile>test7</quarkus.profile>
+              </systemPropertyVariables>
+              <includes>
+                <include>**/*PostgreSQLFilesystemStorageTest.java</include>
+              </includes>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>verify</id>
+            <phase>verify</phase>
+            <goals>
               <goal>verify</goal>
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <includes>
-            <include>**/*PostgreSQLFilesystemStorageTest</include>
-          </includes>
-        </configuration>
       </plugin>
 
       <plugin>

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -9,3 +9,11 @@ quarkus.flyway."database-2".locations=db/migration
 quarkus.flyway."database-2".migrate-at-start=true
 
 quarkus.http.test-port=0
+
+%test.quarkus.embedded.postgresql.listen-address=localhost
+%test2.quarkus.embedded.postgresql.listen-address=127.0.0.1
+%test3.quarkus.embedded.postgresql.listen-address=*
+%test4.quarkus.embedded.postgresql.listen-address=0.0.0.0,::
+%test5.quarkus.embedded.postgresql.listen-address=0.0.0.0
+%test6.quarkus.embedded.postgresql.listen-address=::
+%test7.quarkus.embedded.postgresql.listen-address=::1

--- a/runtime/src/main/java/io/quarkiverse/embedded/postgresql/EmbeddedPostgreSQLConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/embedded/postgresql/EmbeddedPostgreSQLConfig.java
@@ -34,6 +34,24 @@ public interface EmbeddedPostgreSQLConfig {
     Optional<Integer> port();
 
     /**
+     * Optionally configurable host (listen_addresses) for the PostgreSQL server.
+     * <p>
+     * If not set, {@code localhost} is used by default.
+     * Valid values include:
+     * <ul>
+     * <li>{@code localhost} — the loopback interfaces (127.0.0.1 and ::1)</li>
+     * <li>{@code 0.0.0.0} — all IPv4 interfaces</li>
+     * <li>{@code ::} — all IPv6 interfaces</li>
+     * <li>{@code *} — all available IP interfaces (both IPv4 and IPv6)</li>
+     * <li>A specific hostname or IP address, e.g. {@code db.mycompany.local} or {@code 192.168.1.100}</li>
+     * <li>Multiple values separated by commas, e.g. {@code localhost,192.168.1.100}, {@code 0.0.0.0,::}</li>
+     * </ul>
+     *
+     * @return an {@link Optional} containing the hostname(s) or IP address(es) to bind the PostgreSQL server.
+     */
+    Optional<String> listenAddress();
+
+    /**
      * Set string type
      *
      * @see <a href="https://jdbc.postgresql.org/documentation/use/">...</a>

--- a/runtime/src/main/java/io/quarkiverse/embedded/postgresql/EmbeddedPostgreSQLDBUtils.java
+++ b/runtime/src/main/java/io/quarkiverse/embedded/postgresql/EmbeddedPostgreSQLDBUtils.java
@@ -7,14 +7,21 @@ import static io.quarkiverse.embedded.postgresql.EmbeddedPostgreSQLConfigUtils.D
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.sql.DataSource;
 
@@ -26,6 +33,10 @@ import io.zonky.test.db.postgres.embedded.EmbeddedPostgres.Builder;
 public class EmbeddedPostgreSQLDBUtils {
 
     private static final Logger logger = Logger.getLogger(EmbeddedPostgreSQLDBUtils.class);
+
+    private static final List<String> preparedListenAddresses = List.of(
+            String.format("host    %s     %s             0.0.0.0/0            trust", DEFAULT_USERNAME, DEFAULT_DATABASE),
+            String.format("host    %s     %s             ::/0                 trust", DEFAULT_USERNAME, DEFAULT_DATABASE));
 
     private static void createDatabases(EmbeddedPostgres pg, Collection<String> dbNames,
             String userName) {
@@ -48,7 +59,8 @@ public class EmbeddedPostgreSQLDBUtils {
         }
     }
 
-    public static EmbeddedPostgres startPostgres(Optional<Integer> port, Map<String, String> dbNames, String stringType,
+    public static EmbeddedPostgres startPostgres(Optional<Integer> port, Optional<String> listenAddress,
+            Map<String, String> dbNames, String stringType,
             Optional<Long> startUpWait, Optional<String> dataDir) {
         Builder builder = EmbeddedPostgres.builder();
         builder.setConnectConfig("stringtype", stringType);
@@ -56,6 +68,15 @@ public class EmbeddedPostgreSQLDBUtils {
             logger.infov("PG port set to {0}", p);
             builder.setPort(p);
         });
+
+        listenAddress.ifPresent(addr -> {
+            if (!(addr.contains("localhost") || addr.contains("127.0.0.1") && !addr.contains("*"))) {
+                addr = addr + ",localhost";
+            }
+            logger.infov("PG listen_addresses set to {0}", addr);
+            builder.setServerConfig("listen_addresses", addr);
+        });
+
         startUpWait.ifPresent(
                 timeout -> {
                     logger.infov("PG startup timeout set to {0}", timeout);
@@ -72,6 +93,7 @@ public class EmbeddedPostgreSQLDBUtils {
                     "Embedded Postgres started at port \"{0,number,#}\" with database \"{1}\", user \"{2}\" and password \"{3}\"",
                     pg.getPort(), DEFAULT_DATABASE, DEFAULT_USERNAME, DEFAULT_PASSWORD);
             createDatabases(pg, dbNames.values(), DEFAULT_USERNAME);
+            patchPgHbaConfOnNonLocalListenAddr(pg, listenAddress);
             return pg;
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -90,4 +112,31 @@ public class EmbeddedPostgreSQLDBUtils {
 
     private EmbeddedPostgreSQLDBUtils() {
     }
+
+    private static void patchPgHbaConfOnNonLocalListenAddr(EmbeddedPostgres pg, Optional<String> listenAddress) {
+        listenAddress
+                .ifPresent(addr -> {
+                    try (Connection conn = pg.getPostgresDatabase().getConnection()) {
+                        try (PreparedStatement stmt = conn.prepareStatement("SHOW hba_file");
+                                ResultSet rs = stmt.executeQuery()) {
+                            if (rs.next()) {
+                                String hbaFilePath = rs.getString(1);
+                                Path hbaPath = Paths.get(hbaFilePath);
+                                if (Files.exists(hbaPath)) {
+                                    Set<String> lines = new LinkedHashSet<>(Files.readAllLines(hbaPath));
+                                    lines.addAll(preparedListenAddresses);
+                                    Files.write(hbaPath, lines);
+                                    PreparedStatement reloadStmt = conn.prepareStatement("SELECT pg_reload_conf()");
+                                    reloadStmt.executeQuery();
+                                }
+                            }
+                        }
+                    } catch (SQLException e) {
+                        throw new RuntimeException(e);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
+    }
+
 }

--- a/runtime/src/main/java/io/quarkiverse/embedded/postgresql/EmbeddedPostgreSQLRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/embedded/postgresql/EmbeddedPostgreSQLRecorder.java
@@ -10,10 +10,12 @@ import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
 @Recorder
 public class EmbeddedPostgreSQLRecorder {
 
-    public void startPostgres(ShutdownContext shutdownContext, int port, Map<String, String> dbNames, String stringType,
-            Optional<Long> startUpWait, Optional<String> dataDir) {
-        EmbeddedPostgres pg = EmbeddedPostgreSQLDBUtils.startPostgres(Optional.of(port), dbNames, stringType, startUpWait,
-                dataDir);
+    public void startPostgres(ShutdownContext shutdownContext, int port, Optional<String> listenAddress,
+            Map<String, String> dbNames,
+            String stringType, Optional<Long> startUpWait, Optional<String> dataDir) {
+        EmbeddedPostgres pg = EmbeddedPostgreSQLDBUtils.startPostgres(Optional.of(port), listenAddress, dbNames,
+                stringType,
+                startUpWait, dataDir);
         shutdownContext.addShutdownTask(() -> EmbeddedPostgreSQLDBUtils.close(pg));
     }
 }


### PR DESCRIPTION
…nections

@ricardozanini ^^

Here are a few remarks:

1) As far as I understand, by default the password and username are always `postgres`.

2) I allow all IPv4/IPv6 subnets access to the specified address. I don’t think this is dangerous since we’re always limited by the `listen_address`. However, if it’s a problem, I can grant permissions only to the subnets assigned to active network interfaces, though it doesn’t seem necessary to me.