### PR TITLE
Quarkus embedded postgresql issues 81

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -33,13 +33,21 @@
 		</dependency>
 		<dependency>
 			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-vertx-http-deployment</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-vertx-http-dev-ui-spi</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>io.quarkus</groupId>
 			<artifactId>quarkus-jaxp-deployment</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>io.quarkus</groupId>
 			<artifactId>quarkus-vertx-http-dev-ui-spi</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>io.quarkiverse.embedded.postgresql</groupId>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -46,10 +46,6 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>io.quarkus</groupId>
-			<artifactId>quarkus-vertx-http-dev-ui-spi</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>io.quarkiverse.embedded.postgresql</groupId>
 			<artifactId>quarkus-embedded-postgresql</artifactId>
 			<version>${project.version}</version>

--- a/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/EmbeddedPostgreSQLProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/EmbeddedPostgreSQLProcessor.java
@@ -156,6 +156,7 @@ class EmbeddedPostgreSQLProcessor {
                 devServerConfigMap.put(propertyName, config.getConfigValue(propertyName).getValue());
             }
         }
+        devServerConfigMap.put("quarkus.embedded.postgresql.port", String.valueOf(pg.getPort()));
         return new DevServicesResultBuildItem.RunningDevService(FEATURE,
                 null,
                 pg,

--- a/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/EmbeddedPostgreSQLDevUIProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/EmbeddedPostgreSQLDevUIProcessor.java
@@ -15,7 +15,8 @@ import io.quarkus.devui.spi.page.PageBuilder;
 public class EmbeddedPostgreSQLDevUIProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    void createVersion(BuildProducer<CardPageBuildItem> cardPageBuildItemBuildProducer) {
+    void createVersion(BuildProducer<CardPageBuildItem> cardPageBuildItemBuildProducer,
+            PgAdminConfigBuildItem pgAdminConfigBuildItem) {
         final CardPageBuildItem card = new CardPageBuildItem();
 
         final PageBuilder portPage = Page.externalPageBuilder("Port")
@@ -24,6 +25,12 @@ public class EmbeddedPostgreSQLDevUIProcessor {
                 .doNotEmbed()
                 .dynamicLabelJsonRPCMethodName("getDatasourcePort");
         card.addPage(portPage);
+
+        final PageBuilder pgAdminPage = Page.externalPageBuilder("Postgre Admin UI")
+                .icon("font-awesome-solid:database")
+                .url("http://" + pgAdminConfigBuildItem.getPgAdminUrl())
+                .doNotEmbed();
+        card.addPage(pgAdminPage);
 
         card.setCustomCard("qwc-embedded-postgresql-card.js");
         cardPageBuildItemBuildProducer.produce(card);

--- a/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/EmbeddedPostgreSQLDevUIProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/EmbeddedPostgreSQLDevUIProcessor.java
@@ -4,10 +4,13 @@ import io.quarkiverse.embedded.postgresql.devui.EmbeddedPostgreSQLJsonRpcService
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 import io.quarkus.devui.spi.page.PageBuilder;
+import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
+import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConfig;
 
 /**
  * Dev UI card for displaying important details such EmbeddedPostgreSQL embedded UI.
@@ -16,8 +19,12 @@ public class EmbeddedPostgreSQLDevUIProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     void createVersion(BuildProducer<CardPageBuildItem> cardPageBuildItemBuildProducer,
-            PgAdminConfigBuildItem pgAdminConfigBuildItem) {
+            NonApplicationRootPathBuildItem nonApp,
+            ManagementInterfaceBuildTimeConfig mgmtConfig,
+            LaunchModeBuildItem lm) {
         final CardPageBuildItem card = new CardPageBuildItem();
+
+        String managementBase = nonApp.resolveManagementPath("pgadmin", mgmtConfig, lm);
 
         final PageBuilder portPage = Page.externalPageBuilder("Port")
                 .icon("font-awesome-solid:plug")
@@ -28,8 +35,7 @@ public class EmbeddedPostgreSQLDevUIProcessor {
 
         final PageBuilder pgAdminPage = Page.externalPageBuilder("Postgre Admin UI")
                 .icon("font-awesome-solid:database")
-                .url("http://" + pgAdminConfigBuildItem.getPgAdminUrl())
-                .doNotEmbed();
+                .url(managementBase);
         card.addPage(pgAdminPage);
 
         card.setCustomCard("qwc-embedded-postgresql-card.js");

--- a/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAdminConfigBuildItem.java
+++ b/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAdminConfigBuildItem.java
@@ -4,19 +4,19 @@ import io.quarkus.builder.item.SimpleBuildItem;
 
 public final class PgAdminConfigBuildItem extends SimpleBuildItem {
 
-    private final String pgAdminUrl;
-    private final String pgAdminPort;
+    private final String pgAdminHost;
+    private final int pgAdminPort;
 
-    public PgAdminConfigBuildItem(String pgAdminUrl, String pgAdminPort) {
-        this.pgAdminUrl = pgAdminUrl;
+    public PgAdminConfigBuildItem(String pgAdminHost, int pgAdminPort) {
+        this.pgAdminHost = pgAdminHost;
         this.pgAdminPort = pgAdminPort;
     }
 
     public String getPgAdminUrl() {
-        return pgAdminUrl;
+        return pgAdminHost + ":" + pgAdminPort;
     }
 
-    public String getPgAdminPort() {
+    public int getPgAdminPort() {
         return pgAdminPort;
     }
 }

--- a/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAdminConfigBuildItem.java
+++ b/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAdminConfigBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.embedded.postgresql.deployment.devui;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class PgAdminConfigBuildItem extends SimpleBuildItem {
+
+    private final String pgAdminUrl;
+    private final String pgAdminPort;
+
+    public PgAdminConfigBuildItem(String pgAdminUrl, String pgAdminPort) {
+        this.pgAdminUrl = pgAdminUrl;
+        this.pgAdminPort = pgAdminPort;
+    }
+
+    public String getPgAdminUrl() {
+        return pgAdminUrl;
+    }
+
+    public String getPgAdminPort() {
+        return pgAdminPort;
+    }
+}

--- a/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAdminContainer.java
+++ b/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAdminContainer.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.embedded.postgresql.deployment.devui;
+
+import java.nio.file.Path;
+import java.time.Duration;
+
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+public final class PgAdminContainer extends GenericContainer<PgAdminContainer> {
+
+    private static final String DOCKER_IMAGE_NAME = "dpage/pgadmin4:9.4.0";
+
+    public PgAdminContainer(Path serversJsonPath, Path pgpassPath) {
+        super(DockerImageName.parse(DOCKER_IMAGE_NAME));
+        withExposedPorts(80);
+        withEnv("PGADMIN_DEFAULT_EMAIL", "admin@admin.com");
+        withEnv("PGADMIN_DEFAULT_PASSWORD", "admin");
+        withEnv("PGADMIN_CONFIG_SERVER_MODE", "False");
+        withEnv("PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED", "False");
+        withEnv("PGADMIN_REPLACE_SERVERS_ON_STARTUP", "True");
+        withEnv("SCRIPT_NAME", "/pgadmin");
+
+        withFileSystemBind(
+                serversJsonPath.toAbsolutePath().toString(),
+                "/pgadmin4/servers.json",
+                BindMode.READ_ONLY);
+        withFileSystemBind(
+                pgpassPath.toAbsolutePath().toString(),
+                "/pgpass",
+                BindMode.READ_ONLY);
+        waitingFor(Wait.forHttp("/pgadmin/")
+                .forStatusCode(200)
+                .withStartupTimeout(Duration.ofMinutes(2)));
+    }
+}

--- a/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAdminContainer.java
+++ b/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAdminContainer.java
@@ -10,11 +10,15 @@ import org.testcontainers.utility.DockerImageName;
 
 public final class PgAdminContainer extends GenericContainer<PgAdminContainer> {
 
-    private static final String DOCKER_IMAGE_NAME = "dpage/pgadmin4:9.4.0";
+    private static final String DEV_SERVICE_LABEL = "quarkus-dev-service-mailpit";
+    private static final String DEV_SERVICE_NAME = "pgAdminUI";
 
-    public PgAdminContainer(Path serversJsonPath, Path pgpassPath) {
-        super(DockerImageName.parse(DOCKER_IMAGE_NAME));
+    public PgAdminContainer(String dockerImageName, Path serversJsonPath, Path pgpassPath) {
+        super(DockerImageName.parse(dockerImageName));
+        super.withLabel(DEV_SERVICE_LABEL, DEV_SERVICE_NAME);
+
         withExposedPorts(80);
+
         withEnv("PGADMIN_DEFAULT_EMAIL", "admin@admin.com");
         withEnv("PGADMIN_DEFAULT_PASSWORD", "admin");
         withEnv("PGADMIN_CONFIG_SERVER_MODE", "False");

--- a/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAdminProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAdminProcessor.java
@@ -1,0 +1,138 @@
+package io.quarkiverse.embedded.postgresql.deployment.devui;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Collections;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
+import org.jboss.logging.Logger;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkiverse.embedded.postgresql.deployment.EmbeddedPostgreSQLDevServicesConfigBuildItem;
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+
+public class PgAdminProcessor {
+
+    private final static String CONTAINER_ID = "quarkus-embedded-postgresql-pgadmin";
+
+    private final static String QUARKUS_EMBEDDED_POSTGRESQL_PORT = "quarkus.embedded.postgresql.port";
+
+    private final static String PGPASS_TEMPLATE = "host.docker.internal:%s:postgres:postgres:postgres";
+
+    private final static String DOCKER_IMAGE_NAME = "dpage/pgadmin4:9.4.0";
+
+    private static final Logger log = Logger.getLogger(PgAdminProcessor.class);
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    DevServicesResultBuildItem startPgAdminContainer(LaunchModeBuildItem launchMode,
+            EmbeddedPostgreSQLDevServicesConfigBuildItem pgConfig,
+            BuildProducer<PgAdminConfigBuildItem> pgAdminConfigProducer) {
+        if (!launchMode.getLaunchMode().isDevOrTest()) {
+            return null;
+        }
+
+        log.info("Starting PgAdmin container...");
+
+        String serversJson = generateServersJson(
+                Integer.parseInt(pgConfig.getConfig().get(QUARKUS_EMBEDDED_POSTGRESQL_PORT)));
+        String pgPass = generatePgPass(
+                Integer.parseInt(pgConfig.getConfig().get(QUARKUS_EMBEDDED_POSTGRESQL_PORT)));
+
+        Path serversJsonPath;
+        Path pgpassPath;
+        try {
+            serversJsonPath = Files.writeString(Paths.get("servers.json"), serversJson);
+            pgpassPath = Files.writeString(Paths.get("pgpass"), pgPass);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write servers.json, pgpass or config_local.py", e);
+        }
+
+        DockerImageName imageName = DockerImageName.parse(DOCKER_IMAGE_NAME);
+
+        GenericContainer<?> container = new GenericContainer<>(imageName)
+                .withExposedPorts(80)
+                .withEnv("PGADMIN_DEFAULT_EMAIL", "admin@admin.com")
+                .withEnv("PGADMIN_DEFAULT_PASSWORD", "admin")
+                .withEnv("PGADMIN_CONFIG_SERVER_MODE", "False")
+                .withEnv("PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED", "False")
+                .withEnv("PGADMIN_REPLACE_SERVERS_ON_STARTUP", "True")
+                .withFileSystemBind(
+                        serversJsonPath.toAbsolutePath().toString(),
+                        "/pgadmin4/servers.json",
+                        BindMode.READ_ONLY)
+                .withFileSystemBind(
+                        pgpassPath.toAbsolutePath().toString(),
+                        "/pgpass",
+                        BindMode.READ_ONLY)
+                .withLogConsumer(outputFrame -> {
+                    log.info("[PgAdmin4] " + outputFrame.getUtf8String());
+                })
+                .waitingFor(Wait.forHttp("/")
+                        .forStatusCode(200)
+                        .withStartupTimeout(Duration.ofMinutes(2)));
+
+        container.start();
+
+        var config = Collections.singletonMap(
+                "quarkus.pgadmin4.url",
+                container.getHost() + ":" + container.getMappedPort(80));
+
+        pgAdminConfigProducer.produce(new PgAdminConfigBuildItem(
+                config.get("quarkus.pgadmin4.url"),
+                String.valueOf(container.getMappedPort(80))));
+
+        return new DevServicesResultBuildItem.RunningDevService(CONTAINER_ID, container.getContainerId(),
+                () -> {
+                    log.info("Stopping PgAdmin container...");
+                    try {
+                        container.stop();
+                        log.info("PgAdmin container stopped successfully.");
+                    } catch (Exception e) {
+                        log.error("Failed to stop PgAdmin container: " + e.getMessage(), e);
+                    }
+                }, config)
+                .toBuildItem();
+    }
+
+    public String generateServersJson(int port) {
+        JsonObjectBuilder serverBuilder = Json.createObjectBuilder()
+                .add("Name", "Local dev")
+                .add("Group", "Local")
+                .add("Host", "host.docker.internal")
+                .add("Port", port)
+                .add("MaintenanceDB", "postgres")
+                .add("Username", "postgres")
+                .add("PassFile", "/pgpass")
+                .add("SSLMode", "prefer")
+                .add("SavePassword", true);
+
+        JsonObject servers = Json.createObjectBuilder()
+                .add("1", serverBuilder)
+                .build();
+
+        JsonObject root = Json.createObjectBuilder()
+                .add("Servers", servers)
+                .build();
+
+        return root.toString();
+    }
+
+    public String generatePgPass(int port) {
+        String pgPass = String.format(PGPASS_TEMPLATE, port);
+        return pgPass;
+    }
+}

--- a/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAdminProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAdminProcessor.java
@@ -5,7 +5,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.Duration;
 import java.util.Collections;
 
 import jakarta.json.Json;
@@ -13,17 +12,20 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 
 import org.jboss.logging.Logger;
-import org.testcontainers.containers.BindMode;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.DockerImageName;
 
 import io.quarkiverse.embedded.postgresql.deployment.EmbeddedPostgreSQLDevServicesConfigBuildItem;
+import io.quarkiverse.embedded.postgresql.devui.PgAdminUiProxy;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
+import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.RouteBuildItem;
 
 public class PgAdminProcessor {
 
@@ -33,20 +35,42 @@ public class PgAdminProcessor {
 
     private final static String PGPASS_TEMPLATE = "host.docker.internal:%s:postgres:postgres:postgres";
 
-    private final static String DOCKER_IMAGE_NAME = "dpage/pgadmin4:9.4.0";
-
     private static final Logger log = Logger.getLogger(PgAdminProcessor.class);
+
+    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void registerProxy(
+            PgAdminUiProxy recorder,
+            BuildProducer<RouteBuildItem> routes,
+            PgAminUiConfig config,
+            PgAdminConfigBuildItem pgAdminConfigBuildItem,
+            NonApplicationRootPathBuildItem frameworkRoot,
+            CoreVertxBuildItem coreVertx) {
+        if (!config.enabled()) {
+            return;
+        }
+        int port = pgAdminConfigBuildItem.getPgAdminPort();
+
+        routes.produce(frameworkRoot.routeBuilder()
+                .management()
+                .route("pgadmin*")
+                .handler(recorder.handler(coreVertx.getVertx(), port))
+                .build());
+
+        routes.produce(RouteBuildItem.builder()
+                .route("/pgadmin*")
+                .handler(recorder.handler(coreVertx.getVertx(), port))
+                .build());
+    }
 
     @BuildStep(onlyIf = IsDevelopment.class)
     DevServicesResultBuildItem startPgAdminContainer(LaunchModeBuildItem launchMode,
             EmbeddedPostgreSQLDevServicesConfigBuildItem pgConfig,
             BuildProducer<PgAdminConfigBuildItem> pgAdminConfigProducer) {
-        if (!launchMode.getLaunchMode().isDevOrTest()) {
+        if (launchMode.isNotLocalDevModeType()) {
+            log.info("EXITING: PgAdmin is only available in local development mode.");
             return null;
         }
-
-        log.info("Starting PgAdmin container...");
-
         String serversJson = generateServersJson(
                 Integer.parseInt(pgConfig.getConfig().get(QUARKUS_EMBEDDED_POSTGRESQL_PORT)));
         String pgPass = generatePgPass(
@@ -61,30 +85,7 @@ public class PgAdminProcessor {
             throw new UncheckedIOException("Failed to write servers.json, pgpass or config_local.py", e);
         }
 
-        DockerImageName imageName = DockerImageName.parse(DOCKER_IMAGE_NAME);
-
-        GenericContainer<?> container = new GenericContainer<>(imageName)
-                .withExposedPorts(80)
-                .withEnv("PGADMIN_DEFAULT_EMAIL", "admin@admin.com")
-                .withEnv("PGADMIN_DEFAULT_PASSWORD", "admin")
-                .withEnv("PGADMIN_CONFIG_SERVER_MODE", "False")
-                .withEnv("PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED", "False")
-                .withEnv("PGADMIN_REPLACE_SERVERS_ON_STARTUP", "True")
-                .withFileSystemBind(
-                        serversJsonPath.toAbsolutePath().toString(),
-                        "/pgadmin4/servers.json",
-                        BindMode.READ_ONLY)
-                .withFileSystemBind(
-                        pgpassPath.toAbsolutePath().toString(),
-                        "/pgpass",
-                        BindMode.READ_ONLY)
-                .withLogConsumer(outputFrame -> {
-                    log.info("[PgAdmin4] " + outputFrame.getUtf8String());
-                })
-                .waitingFor(Wait.forHttp("/")
-                        .forStatusCode(200)
-                        .withStartupTimeout(Duration.ofMinutes(2)));
-
+        PgAdminContainer container = new PgAdminContainer(serversJsonPath, pgpassPath);
         container.start();
 
         var config = Collections.singletonMap(
@@ -92,8 +93,7 @@ public class PgAdminProcessor {
                 container.getHost() + ":" + container.getMappedPort(80));
 
         pgAdminConfigProducer.produce(new PgAdminConfigBuildItem(
-                config.get("quarkus.pgadmin4.url"),
-                String.valueOf(container.getMappedPort(80))));
+                container.getHost(), container.getMappedPort(80)));
 
         return new DevServicesResultBuildItem.RunningDevService(CONTAINER_ID, container.getContainerId(),
                 () -> {

--- a/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAminUiConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAminUiConfig.java
@@ -9,7 +9,7 @@ import io.smallrye.config.WithDefault;
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
 public interface PgAminUiConfig {
 
-    String DEFAULT_IMAGE = "dpage/pgadmin4:9.4.0";
+    String DEFAULT_IMAGE = "dpage/pgadmin4:9.5.0";
 
     /**
      * Enable or disable the PgAdmin UI.

--- a/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAminUiConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAminUiConfig.java
@@ -1,0 +1,30 @@
+package io.quarkiverse.embedded.postgresql.deployment.devui;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "quarkus.pgadmin-ui")
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public interface PgAminUiConfig {
+
+    String DEFAULT_IMAGE = "dpage/pgadmin4:9.4.0";
+
+    /**
+     * Enable or disable the PgAdmin UI.
+     *
+     * @return true if enabled, false otherwise
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
+     * The name of the Docker image to use for PgAdmin.
+     *
+     * @return the Docker image name
+     */
+    @WithDefault(DEFAULT_IMAGE)
+    String imageName();
+
+}

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -44,11 +44,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-vertx-http</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-vertx-http</artifactId>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -48,6 +48,14 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-vertx-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-agroal</artifactId>
       <optional>true</optional>
     </dependency>

--- a/runtime/src/main/java/io/quarkiverse/embedded/postgresql/devui/PgAdminUiProxy.java
+++ b/runtime/src/main/java/io/quarkiverse/embedded/postgresql/devui/PgAdminUiProxy.java
@@ -1,0 +1,62 @@
+package io.quarkiverse.embedded.postgresql.devui;
+
+import java.util.function.Supplier;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.annotations.Recorder;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.client.WebClient;
+
+@Recorder
+public class PgAdminUiProxy {
+
+    private static final Logger log = Logger.getLogger(PgAdminUiProxy.class);
+
+    private static final String MAIN_PAGE = "/q/pgadmin";
+
+    private static final String RESOURCES = "/pgadmin";
+
+    public Handler<RoutingContext> handler(Supplier<Vertx> vertx, int port) {
+        final var client = WebClient.create(vertx.get());
+
+        return event -> {
+            String suffix;
+            String rawUri = event.request().uri();
+            if (rawUri.startsWith(MAIN_PAGE)) {
+                suffix = rawUri.substring(MAIN_PAGE.length());
+            } else if (rawUri.startsWith(RESOURCES)) {
+                suffix = rawUri.substring(RESOURCES.length());
+            } else {
+                event.response().setStatusCode(404).end();
+                return;
+            }
+
+            client.request(event.request().method(),
+                    port,
+                    "localhost",
+                    "/pgadmin" + suffix)
+                    .followRedirects(true)
+                    .putHeaders(event.request().headers())
+                    .sendBuffer(event.request().body().result()).onComplete(
+                            resp -> {
+                                if (resp.succeeded()) {
+                                    event.response().setStatusCode(resp.result().statusCode());
+                                    resp.result().headers().forEach(h -> event.response().putHeader(h.getKey(), h.getValue()));
+                                    Buffer body = resp.result().body();
+                                    if (body != null && body.length() > 0) {
+                                        event.response().end(body);
+                                    } else {
+                                        event.response().end();
+                                    }
+                                } else {
+                                    log.error("Failed to proxy request to PgAdmin UI", resp.cause());
+                                    event.response().setStatusCode(500).end();
+                                }
+                            });
+        };
+    }
+}


### PR DESCRIPTION
@ricardozanini 

In DevMode, pgAdmin is launched and configured to work with the embedded PostgreSQL so that you don’t need to enter a URL, username, or password. In the DevUI, we’ve added an option to open pgAdmin in a new tab. I tried to have pgAdmin open in an iframe within the DevUI, but due to CORS this doesn’t work. It might be possible using a reverse proxy; if needed, let’s create another issue and I’ll try that approach.

In my view, this isn’t necessary, since the pgAdmin interface is already very full-featured, and it’s better to use it full-screen rather than in the limited space provided by the DevUI.

Attention: [this](https://github.com/quarkiverse/quarkus-embedded-postgresql/pull/147) PR needs to be merged first!