### PR TITLE
ISSUE_152: pgAdmin Dev Service: Respect enabled flag

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/EmbeddedPostgreSQLDevUIProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/EmbeddedPostgreSQLDevUIProcessor.java
@@ -21,7 +21,8 @@ public class EmbeddedPostgreSQLDevUIProcessor {
     void createVersion(BuildProducer<CardPageBuildItem> cardPageBuildItemBuildProducer,
             NonApplicationRootPathBuildItem nonApp,
             ManagementInterfaceBuildTimeConfig mgmtConfig,
-            LaunchModeBuildItem lm) {
+            LaunchModeBuildItem lm,
+            PgAminUiConfig pgAppConfig) {
         final CardPageBuildItem card = new CardPageBuildItem();
 
         String managementBase = nonApp.resolveManagementPath("pgadmin", mgmtConfig, lm);
@@ -32,12 +33,13 @@ public class EmbeddedPostgreSQLDevUIProcessor {
                 .doNotEmbed()
                 .dynamicLabelJsonRPCMethodName("getDatasourcePort");
         card.addPage(portPage);
-
-        final PageBuilder pgAdminPage = Page.externalPageBuilder("pgAdmin UI")
-                .icon("font-awesome-solid:database")
-                .url(managementBase, managementBase)
-                .isHtmlContent();
-        card.addPage(pgAdminPage);
+        if (pgAppConfig.enabled()) {
+            final PageBuilder pgAdminPage = Page.externalPageBuilder("pgAdmin UI")
+                    .icon("font-awesome-solid:database")
+                    .url(managementBase, managementBase)
+                    .isHtmlContent();
+            card.addPage(pgAdminPage);
+        }
 
         card.setCustomCard("qwc-embedded-postgresql-card.js");
         cardPageBuildItemBuildProducer.produce(card);

--- a/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAdminProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/embedded/postgresql/deployment/devui/PgAdminProcessor.java
@@ -78,6 +78,11 @@ public class PgAdminProcessor {
             log.info("EXITING: PgAdmin is only available in local development mode.");
             return null;
         }
+        if (!pgAppConfig.enabled()) {
+            log.info("EXITING: PgAdmin is disabled in the configuration.");
+            return null;
+        }
+
         String serversJson = generateServersJson(
                 Integer.parseInt(pgBuildConfig.getConfig().get(QUARKUS_EMBEDDED_POSTGRESQL_PORT)));
         String pgPass = generatePgPass(


### PR DESCRIPTION
https://github.com/quarkiverse/quarkus-embedded-postgresql/issues/152

1) do not add a link to the pgAdmin, if `quarkus.pgadmin-ui.enabled=false`
2) do not start the container (just exit the method) if `quarkus.pgadmin-ui.enabled=false`